### PR TITLE
refactor: Remove source array support from .generate

### DIFF
--- a/DocBox.cfc
+++ b/DocBox.cfc
@@ -98,9 +98,9 @@ component accessors="true" {
 	 * @return The DocBox instance
 	 */
 	DocBox function generate(
-		required source,
-		string mapping  = "",
-		string excludes = ""
+		required string source,
+		required string mapping,
+		required string excludes
 	){
 		// verify we have at least one strategy defined
 		if ( isNull( getStrategies() ) || !getStrategies().len() ) {


### PR DESCRIPTION
BREAKING CHANGE: The `source` argument to `docbox.generate()` must be
a string now - arrays are not supported.

Please merge this PR to test the github actions build...